### PR TITLE
ci: fix nuclei-action inputs and source go version from go.mod

### DIFF
--- a/.github/workflows/scheduled_job.yaml
+++ b/.github/workflows/scheduled_job.yaml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 env:
   REPO_OWNER: ${{ github.repository_owner }}
-  NUCLEI_VERSION: '3.2.5'
+  # renovate: datasource=github-releases depName=projectdiscovery/nuclei
+  NUCLEI_VERSION: 'v3.2.5'
 
 jobs:
   project-runner:
@@ -32,9 +33,16 @@ jobs:
       - name: Nuclei - Vulnerability Scan
         uses: projectdiscovery/nuclei-action@cc153d0541e1adf8a42bbe31c0a4fb2376147538 # v3.1.1
         with:
-          target: "http://127.0.0.1:8080"
-          flags: "-t http/cves -type http -stats -ni -sresp"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.NUCLEI_VERSION }}
+          args: >-
+            -target http://127.0.0.1:8080
+            -t http/cves
+            -tags ${{ env.TAG }}
+            -type http
+            -stats
+            -ni
+            -sresp
+            -srd output
 
       - name: zip output
         run: |
@@ -63,7 +71,7 @@ jobs:
         - name: Setup Go
           uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
           with:
-            go-version: '^1.22.3'
+            go-version-file: 'go.mod'
 
         - name: Download artifacts
           uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Summary
- Use the v3 `nuclei-action` input names (`version`, `args`) — the previous `target` / `flags` / `github-token` inputs were silently ignored, so the scan was effectively running with defaults
- Wire the existing `TAG` env into the scan via `-tags`, and write trace output under `output/` (`-srd output`) where the artifact upload step expects it
- Drop the explicit `token` since the action defaults to `${{ github.token }}`
- Switch `actions/setup-go` to `go-version-file: 'go.mod'` so `go.mod` is the single source of truth (currently `go 1.25.0` / `toolchain go1.26.2`); Renovate manages `go.mod` natively
- Add a Renovate annotation on `NUCLEI_VERSION` (github-releases / projectdiscovery/nuclei)

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` and confirm Nuclei runs with the expected args and pinned version
- [ ] Verify the `output` artifact contains trace files and the `Generate report` job produces non-zero `total_requests`
- [ ] Confirm Renovate picks up `NUCLEI_VERSION` on its next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)